### PR TITLE
fix: clean trace compass during make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ _install:
 
 .PHONY: clean
 clean:
+	cd trace_compass && make clean
 	rm -rf ros2tools.egg-info build  dist ros2tools/__pycache__ 
 	rm -rf build
 	docker rmi ${DOCKER_IMAGE} --force || true


### PR DESCRIPTION
The main Makefile does not clean up trace_compass during make clean, leaving a stray trace_compass image. Added a line similar to make build solving this issue.